### PR TITLE
It requires a non nil email in email2()

### DIFF
--- a/bin/html2mail
+++ b/bin/html2mail
@@ -47,6 +47,7 @@ end
 desc 'Convert HTML file with images to eml'
 arg 'files', multiple: true, desc: "HTML-files to process"
 command :convert do |c|
+  c.flag [:t, :to], default_value: ''
   c.switch [:s, :stdout], default_value: false
   c.flag [:o, :output], default_value: nil
 


### PR DESCRIPTION
That line failed in mail2():

`html_string = File.read(html_file).gsub('[%%FEmail%%]', email)`

Error without email is: `error: no implicit conversion of nil into String`